### PR TITLE
fix: 이미지 다운로드 캐쉬 이슈 해결

### DIFF
--- a/src/components/workspace/WorkChat.vue
+++ b/src/components/workspace/WorkChat.vue
@@ -192,8 +192,11 @@ const downloadImage = async (url) => {
   try {
     // Axios 요청
     const response = await axios.get(url, {
-      responseType: 'blob', // Blob으로 응답 받기
-      withCredentials: false, // CORS 문제 방지
+      responseType: 'blob',
+      withCredentials: false,
+      headers: {
+        'Cache-Control': 'no-cache',
+      },
     });
 
     // Blob 데이터 생성


### PR DESCRIPTION
🌟개요
---
📋작업사항
--- 프론트에서 이미지 다운로드 요청시 헤더에 캐쉬 제거
